### PR TITLE
Stage lighting with MIDI: Arduino DMX controller

### DIFF
--- a/404.txt
+++ b/404.txt
@@ -58,6 +58,7 @@ interested in travelling stories, life journeys, startups, commercial sh*t,
   PR39 bLED - Blaze Light Emitting Display ............................... @K5T5
   PR41 (Ne)alaus mini degustacija ........................................ Laima
   PR38 Making your first DND 5e player character ................... @saint66735
+  PR44 Stage lighting with MIDI: Arduino DMX controller ........... @shvytejimas
 
 
 --[ SOUND ]


### PR DESCRIPTION
A live demo of a small setup, which allows one to control DMX-enabled stage lighting equipment using a DIY Arduino controller and optionally use a MIDI controller as an input device.
Includes a short backstory why and how this came to be and ideas how this can be extended further.