### PR TITLE
ID kortelės el. parašo aplikacija (-os): veikimas ir klaidos

### DIFF
--- a/404.txt
+++ b/404.txt
@@ -1,4 +1,4 @@
-﻿                             _  _    ___  _  _
+                             _  _    ___  _  _
                             | || |  / _ \| || |
                             | || |_| | | | || |_
                             |__   _| | | |__   _|
@@ -31,6 +31,7 @@ interested in travelling stories, life journeys, startups, commercial sh*t,
   PR1  Intro: Camp Not Found ............................................ @pawka
   PR52 Ham radio: flying a high altitude balloon around the Earth ..... @kareiva
   PR53 Building mechanical keyboards .................................... @pawka
+  PR54 ID kortelės el. parašo aplikacija (-os): veikimas ir klaidos ..... @monai
 
 
 --[ SOUND ]

--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@ interested in travelling stories, life journeys, startups, commercial sh*t,
 
   <a href="https://github.com/ntacamp/404.notrollsallowed.com/pull/1">PR1</a>  Intro: Camp Not Found ............................................ <a href="https://github.com/pawka">@pawka</a>
   <a href="https://github.com/ntacamp/404.notrollsallowed.com/pull/52">PR52</a> Ham radio: flying a high altitude balloon around the Earth ..... <a href="https://github.com/kareiva">@kareiva</a>
+  <a href="https://github.com/ntacamp/404.notrollsallowed.com/pull/53">PR53</a> Building mechanical keyboards .................................... <a href="https://github.com/pawka">@pawka</a>
 
 
 --[ SOUND ]


### PR DESCRIPTION
Pernai pasakojau apie Lietuvos ID kortelės kelionės dokumentų bekontaktę aplikaciją ir šiek tiek užsiminiau apie kontaktinę el. parašo aplikaciją. Šiemet pristatysiu ką pavyko išsiaiškinti per metus apie ją.

Mano kortelės reverse engineerinimo išeities taškas buvo dveji PKCS11 draiveriai: PWPW ir Cryptotech, palaikantys tą pačią kortelės aplikaciją `SmartApp`. Kortelėje iš tikrųjų yra ir veikia (iš dalies) ne viena el. parašo aplikacija. PKCS11 draiveriai duoda priėjimą prie daugiau funkcionalumo, nei yra skelbiama viešai. Taip pat, išduodant kortelę išduodami kredencialai yra nepakankami galutiniam vartotojui naudotis visu kortelės funkcionalumu.

Rezultatas yra nepriklausoma pasirašymo implementacija. Mano parašytas kodas [1] pasirašo duomenis kortelėje esančiu privačiu raktu visiškai nenaudodamas originalių draiverių.

Papasakosiu apie kortelės aplikacijų struktūrą, vartotojo autentikacijos būdus, draiveriu klaidas, kas kortelėje veikia, kas neveikia ir kaip sekėsi reverse engineerinti.

[1] https://github.com/monai/node-passport
