### PR TITLE
Potato baking in campfire workshop

### DIFF
--- a/404.txt
+++ b/404.txt
@@ -46,6 +46,7 @@ interested in travelling stories, life journeys, startups, commercial sh*t,
   PR69 Išmaniai išmanūs namai nerašant kodo ................................ @2m
   PR70 Lessons learned during NATO cybersecurity exercise ............... @edast
   PR71 Alternate reality game - what is it? ...................... Agota Foxtail
+  PR74 Potato baking in campfire workshop ..................... Donatas Remeika
 
 
 --[ SOUND ]


### PR DESCRIPTION
Self-proclaimed campfire potato baking professional will prepare, teach and cook potatoes.   
Smaller kids should be supervised by adults as workshop will contain:   
* Fire
* Possibly sharp knives
