### PR TITLE
Mobilaus parašo duomenų perėmimas tarp telefono ir SIM

### DIFF
--- a/404.txt
+++ b/404.txt
@@ -33,6 +33,7 @@ interested in travel stories, life journeys, startups, commercial sh*t,
   PR112 DIY Apartment smart lock ..................................... @Atstovas
   PR113 Open-Source smart home with HomeAssistant ............. @justinasjaronis
   PR114 Live coding visual performances ............................. @domnantas
+  PR115 Mobilaus parašo duomenų perėmimas tarp telefono ir SIM .......... @monai
 
 
 --[ SOUND ]

--- a/404.txt
+++ b/404.txt
@@ -33,7 +33,7 @@ interested in travel stories, life journeys, startups, commercial sh*t,
   PR112 DIY Apartment smart lock ..................................... @Atstovas
   PR113 Open-Source smart home with HomeAssistant ............. @justinasjaronis
   PR114 Live coding visual performances ............................. @domnantas
-  PR115 Mobilaus parašo duomenų perėmimas tarp telefono ir SIM .......... @monai
+  PR116 Mobilaus parašo duomenų perėmimas tarp telefono ir SIM .......... @monai
 
 
 --[ SOUND ]


### PR DESCRIPTION
SIM kortelės mobilaus parašo aplikacija užklausą pasirašyti gauna, o parašą išsiunčia, SMS žinutėmis. Šias žinutes perimti lengviausia tarp fiznių kortelės ir telefono jungčių. Pranešime papasakosiu apie visą savo stacką nuo kabelių iki SMS paketų decoderio. Visą software dalį, pradedant SmartCard transporto protokolo analizatoriumi, įgyvendinau pats. Parodysiu per kiek sluoksnių protokolų/paketų/konteinerių turi praeiti užklausa kol pasiekia Card Application Toolkit aplikaciją, kuri ir atlieka pasirašymą.