### PR TITLE
Deconstructing 'The Zen of Python'"

### DIFF
--- a/404.txt
+++ b/404.txt
@@ -47,7 +47,7 @@ interested in travel stories, life journeys, startups, commercial sh*t,
   PR128 Participating (and winning) in NATO cybersecurity exercise ...... @edast
   PR129 Lobių ir pamestų daiktų paieškos ...................... Kristijonas Mozė
   PR126 Making Krupnikas: Easier to produce than you'd think ......… . @TadasViz
-  PR130 Deconstructing 'The Zen of Python'" ............................. @aidiss
+  PR130 Deconstructing 'The Zen of Python'" ............................ @aidiss
 
 
 --[ SOUND ]

--- a/404.txt
+++ b/404.txt
@@ -47,6 +47,7 @@ interested in travel stories, life journeys, startups, commercial sh*t,
   PR128 Participating (and winning) in NATO cybersecurity exercise ...... @edast
   PR129 Lobių ir pamestų daiktų paieškos ...................... Kristijonas Mozė
   PR126 Making Krupnikas: Easier to produce than you'd think ......… . @TadasViz
+  PR130 Deconstructing 'The Zen of Python'" ............................. @aidiss
 
 
 --[ SOUND ]


### PR DESCRIPTION
The Zen of Python is a collection of 19 "guiding principles" for writing computer programs that influence the design of the Python programming language. In this talk we will philosophically deconstruct and assess The Zen of Python as a whole, each guiding principle separately and compared to each other. Expect comparison to be done Tier List or Playoff fashion. 

https://en.wikipedia.org/wiki/Zen_of_Python
https://peps.python.org/pep-0020/#the-zen-of-python

The Zen of Python

```
Beautiful is better than ugly.
Explicit is better than implicit.
Simple is better than complex.
Complex is better than complicated.
Flat is better than nested.
Sparse is better than dense.
Readability counts.
Special cases aren't special enough to break the rules.
Although practicality beats purity.
Errors should never pass silently.
Unless explicitly silenced.
In the face of ambiguity, refuse the temptation to guess.
There should be one– and preferably only one –obvious way to do it.
Although that way may not be obvious at first unless you're Dutch.
Now is better than never.
Although never is often better than right now.
If the implementation is hard to explain, it's a bad idea.
If the implementation is easy to explain, it may be a good idea.
Namespaces are one honking great idea – let's do more of those!
TBA
```