### PR TITLE
Ukrainiečiai Lietuvoje: pabėgėlių centro kasdienybė

### DIFF
--- a/404.txt
+++ b/404.txt
@@ -47,7 +47,7 @@ interested in travel stories, life journeys, startups, commercial sh*t,
   PR128 Participating (and winning) in NATO cybersecurity exercise ...... @edast
   PR129 Lobių ir pamestų daiktų paieškos ...................... Kristijonas Mozė
   PR126 Making Krupnikas: Easier to produce than you'd think ......… . @TadasViz
-
+  PR131 Ukrainiečiai Lietuvoje: pabėgėlių centro kasdienybė .............. Aistė
 
 --[ SOUND ]
 


### PR DESCRIPTION
Nuo karo pradžios Lietuvoje pradėjo veikti keli ukrainiečiams skirti pabėgėlių registracijos centrai. Apie tai, su kokiomis bėdomis ir rūpesčiais į juos kreipiasi žmonės, kaip čia lankytojus pasitinkame ir pasirūpiname, kviesiu pažvelgti Raudonojo Kryžiaus savanorių akimis. 