### PR TITLE
Taksofonų eros pabaiga Lietuvoje (ir kas iš to liko)

### DIFF
--- a/404.txt
+++ b/404.txt
@@ -62,6 +62,7 @@ interested in travel stories, life journeys, startups, commercial sh*t,
   PR143 Workshop: Piešimo pagrindai (ką mokė dailės mokykloj) ......... Kristina
   PR144 VR on the Web ................................................ @cheloveq
   PR145 Workshop: Jam. The one with instruments. Musical ones ....... @Palivonas
+  PR148 Taksofonų eros pabaiga Lietuvoje (ir kas iš to liko) .......... @ABLomas
 
 
 --[ SOUND ]


### PR DESCRIPTION
## Eros pabaiga: Lietuvoje išjungtas paskutinis veikęs viešas taksofonas

Pranešėjas: @ABlomas

Lietuvoje buvo išjungtas paskutinis Lietuvoje veikęs viešasis telefonas – taksofonas. Paskutinių aparato išmontavimo aktas simboliškai užbaigė 89 metus trukusią Lietuvos taksofonų istoriją: pirmieji taksofonai šalyje pradėjo veikti 1913 m.
