### PR TITLE
PR168: Connecting your grandma's rotary phone to modern PSTNs 

### DIFF
--- a/404.txt
+++ b/404.txt
@@ -28,7 +28,7 @@ into some framework" type of topics.
   PR163 Intro: No Tolls Allowed #11 ..................................... @pawka
   PR165 Extending C#: How we got tired of boilerplate and added macros  @arturaz
   PR166 Running image generation locally 101 .......................... @singler
-  PR167 Connecting your grandma's rotary phone to modern PSTNs ........ @kareiva
+  PR168 Connecting your grandma's rotary phone to modern PSTNs ........ @kareiva
 
 
 --[ SOUND ]


### PR DESCRIPTION
A short story and a workshop including some working landline/rotary phones that you can call from your mobile phone.

* How were phone calls placed 50 years ago?

* How did the limitations of the old PSTN networks impact the dawn of the Internet?

* What can we learn from connecting old equipment to modern IP telephony networks?

We will have fun and call the hacker camp in the woods by dialing +370 5 207 7936