### PR TITLE
PR179 Moksliukiška Čiulų dvaro restauracija

### DIFF
--- a/404.txt
+++ b/404.txt
@@ -39,6 +39,7 @@ into some framework" type of topics.
   PR175 Teisės į intelektinę nuosavybę, kodėl robotas negali būti autorius . @KJ
   PR176 Elektroniniai muzikos instrumentai 90-ųjų DIY scenoje .......... Marukas
   PR177 Attraction: Bookshelf of old IT-related books ........… . Renardas (KMS)
+  PR179 Moksliukiškas požiūris į paveldo restauraciją (Čiulai) .......... Aistis
 
 
 --[ SOUND ]


### PR DESCRIPTION
### Čiulų dvaro detektyvai

Aistis ir Elena Šimaičiai

• 2017 m. ieškodami sodybos atsitiktinai įsigijome apleistą medinį dvarą, o šiemet pradėjome restauracijos darbus.
• Papasakosime apie paveldo tyrimų maratoną ir jo rezultatus, kaip išsiaiškinti kaip iš tikrųjų atrodė dvaras (išplanavimas, architektūra, spalvos, krosnys) vien tik tyrinėjant pastatą.
• Parodysime kaip atrodo domkratais pakeltas namas ir storiausia Lietuvos tuopa.
• Pasvarstysime kokia tikimybė, kad šiame dvare viešėjo Napoleonas.
• Pasidalinsime planais įkurti dvare Skaičių muziejų.