### PR TITLE
Akademinės tarptautinių santykių teorijos: kada (ne)kariaujama?

### DIFF
--- a/404.txt
+++ b/404.txt
@@ -38,6 +38,7 @@ into some framework" type of topics.
   PR250 Groups vs teams: differences in decision making process ....... @rutaisa
   PR251 My approach to Personal Knowledge Management (PKM) .......... @4giedrius
   PR252 Scuba Diving 101: Practical Intro to Underwater Exploration .... @rockaz
+  PR253 Akadem. tarptautinių santykių teorijos, kada (ne)kariaujama..@berzasprod
 
 
 --[ SOUND ]


### PR DESCRIPTION
Akademinės tarptautinių santykių teorijos.
Esu baigęs politikos mokslų baklaurą VU. Tai, man įdomiausia tema. Adakeminės tarptautinių santykių teorijos, užuot aiškinusios konkretaus karo priežastis, ieško universalių taisyklių kodėl valsybės kariauja arba ne. Pristatysiu populiariausias: realizmo, liberaliają, konstruktyvizmo. Remsiuosi Kissinger, Mearsheimer ir akademine literatūra.