### PR TITLE
Waxing bike chains for fun and profit

### DIFF
--- a/404.txt
+++ b/404.txt
@@ -40,6 +40,7 @@ into some framework" type of topics.
   PR252 Scuba Diving 101: Practical Intro to Underwater Exploration .... @rockaz
   PR253 Akadem. tarptautinių santykių teorijos, kada (ne)kariaujama  @berzasprod
   PR254 Attraction: Bookshelf of old IT-related books ..........…  Renardas (KMS)
+  PR256 Waxing bike chains for fun and profit ............................ @alga
 
 
 --[ SOUND ]


### PR DESCRIPTION
Lubricating bicycle chains by immersion in molten paraffin wax has been known for about a century.  However, it has grown in popularity in recent years, as the advantages in friction losses and chain longevity have been rediscovered.  I have used waxed chains for about 4 years and 30 000 km.  I will present my pragmatic, economical and low-effort approach to chain waxing.