### PR TITLE
ARDF – elektroninių lapių medžioklė

### DIFF
--- a/404.txt
+++ b/404.txt
@@ -48,6 +48,7 @@ into some framework" type of topics.
   PR260 Kaip man DBT padėjo valdyti įtampą ir jausmus ................. @kuuskus
   PR262 Crokinole: learn to play workshop .............................. @tadkle
   PR263 Beer making 101 + tasting .................................. @saint66735
+  PR264 ARDF – elektroninių lapių medžioklė.......................... @domnantas
 
 
 --[ SOUND ]

--- a/index.html
+++ b/index.html
@@ -67,6 +67,7 @@ into some framework" type of topics.
   <a href="https://github.com/ntacamp/404.notrollsallowed.com/pull/260">PR260</a> Kaip man DBT padėjo valdyti įtampą ir jausmus ................. <a href="https://github.com/kuuskus">@kuuskus</a>
   <a href="https://github.com/ntacamp/404.notrollsallowed.com/pull/262">PR262</a> Crokinole: learn to play workshop .............................. <a href="https://github.com/tadkle">@tadkle</a>
   <a href="https://github.com/ntacamp/404.notrollsallowed.com/pull/263">PR263</a> Beer making 101 + tasting .................................. <a href="https://github.com/saint66735">@saint66735</a>
+  <a href="https://github.com/ntacamp/404.notrollsallowed.com/pull/264">PR264</a> ARDF – elektroninių lapių medžioklė.......................... <a href="https://github.com/domnantas">@domnantas</a>
 
 
 --[ SOUND ]


### PR DESCRIPTION
Sportinė radiopelengacija (ARDF, amateur radio direction finding) yra įdomi sporto šaka apjungianti technologijas/elektroniką ir aktyvų laisvalaikį gamtoje. Sportininkai žemėlapio, kompaso ir specialaus radijo imtuvo pagalba miške ieško mažos galios siųstuvų, kurios vadinamos "lapėmis". Šis užsiėmimas tinka ir mažiesiems, ir vyresniems (Lietuvoje turime keletą 75+ m. sportininkų ir sportininkių).

Stovyklos teritorijoje paruošiu trumpą ARDF trasą, vesiu instruktažus visiems norintiems, o dalyviai galės varžytis kas greičiau suras lapes.