### PR TITLE
Programų atestacijos Apple įrenginiuose problemos

### DIFF
--- a/404.txt
+++ b/404.txt
@@ -51,6 +51,7 @@ into some framework" type of topics.
   PR264 ARDF – elektroninių lapių medžioklė ......................... @domnantas
   PR265 Esu Mechanikas pas Ryanair'a, Avia mech darbo specifika +QA .... Douglas
   PR277 Raktų pakabukų pynimo dirbtuvės ................................... Ieva
+  PR278 Programų atestacijos Apple įrenginiuose problemos ............... @monai
 
 
 --[ SOUND ]

--- a/404.txt
+++ b/404.txt
@@ -51,7 +51,7 @@ into some framework" type of topics.
   PR264 ARDF – elektroninių lapių medžioklė ......................... @domnantas
   PR265 Esu Mechanikas pas Ryanair'a, Avia mech darbo specifika +QA .... Douglas
   PR277 Raktų pakabukų pynimo dirbtuvės ................................... Ieva
-  PR278 Programų atestacijos Apple įrenginiuose problemos ............... @monai
+  PR268 Programų atestacijos Apple įrenginiuose problemos ............... @monai
 
 
 --[ SOUND ]


### PR DESCRIPTION
Programos veikiančios Apple iĮrenginiuose turi galimybę gauti iš Apple ir trečiosioms šalims pateikti programos atestacijos pranešimą, kuris šia schema pasitikinčiai šaliai praneša, kad jį sugeneravusi programa yra nemodifikuota ir veikia taip, kaip jos kūrėjų sumanyta. Funkcionalumas yra reikalingas, intencija yra sveikinta, o įgyvendinimas - prastas. Todėl iĮrenginiuose iš principo negali būti saugiai įgyvendinta ištisa klasė autentikacijai skirtų programų. O tos, kurios egzistuoja, visos yra pažeidžiamos.

Bus iliustracijų konkrečiais pavyzdžiais.