### PR TITLE
PR278 Be emocijų nėra intelekto

### DIFF
--- a/404.txt
+++ b/404.txt
@@ -59,6 +59,7 @@ into some framework" type of topics.
   PR271 Vyrai ir pedikiūras: kodėl verta rūpintis savo pėdomis ......... Paulina
   PR273 DIY PAPR oro filtravimo sistema ..................... @jonasAndriusiunas
   PR274 Edukacija apie bites ....................................... @arturasjas
+  PR278 Be emocijų nėra intelekto ...................................... Emilija
 
 
 --[ SOUND ]


### PR DESCRIPTION
Psichiterapinio darbo praktika paremtas pranešimas apie emocijų teorijas, mokymąsi ir intelektą. Emocijos yra viso kūno sistemos dalis, priklausoma nuo to, su kokiais duomenimis susiduria, įgimtų smegeneų savybių talpinti ir apdoroti gautą informaciją ir įgytų savybių (mokymosi). Papasakosiu kodėl vienos populiarios emocijų teorijos yra nepraktiškos, o kitos gali padėti geriau suprasti save, aplinkinius ir dirbtinį intelektą.