### PR TITLE
Automating 3D printing on repeat

### DIFF
--- a/404.txt
+++ b/404.txt
@@ -70,6 +70,7 @@ into some framework" type of topics.
   PR285 Moto trials - smagiau, saugiau, pigiau, daugiau progreso .... @Palivonas
   PR286 100-mečio Lietuvos dainų šventė iš vidaus .................. Austėja KMS
   PR287 RC plane upgrade with an autopilot and video streaming ........ @singler
+  PR288 3D printing on repeat ................................. @ViliusKraujutis
 
 
 --[ SOUND ]

--- a/404.txt
+++ b/404.txt
@@ -70,7 +70,7 @@ into some framework" type of topics.
   PR285 Moto trials - smagiau, saugiau, pigiau, daugiau progreso .... @Palivonas
   PR286 100-mečio Lietuvos dainų šventė iš vidaus .................. Austėja KMS
   PR287 RC plane upgrade with an autopilot and video streaming ........ @singler
-  PR288 3D printing on repeat ................................. @ViliusKraujutis
+  PR292 3D printing on repeat ................................. @ViliusKraujutis
 
 
 --[ SOUND ]


### PR DESCRIPTION
Usually, after each build plate 3D printing is complete - you need to pick-up all parts manually. To reduce manual work for picking up parts, you can:
- fit as many parts as you can on a print bed, so manual work would be done in larger bulks
- automate printing and discarding the a single part automatically without manual intervention.

The presentation will be about the journey to this automated 3D printing cycle.