### PR TITLE
PR293: camp tv + teletext

### DIFF
--- a/404.txt
+++ b/404.txt
@@ -75,6 +75,7 @@ into some framework" type of topics.
   PR290 Let's create LLM party to replace Lithuanian government ........ @aidiss
   PR291 Naujas trendas parkuose - SpikeBall aka Smūginis. Pažaisim ..... @darles
   PR292 3D printing on repeat ................................. @ViliusKraujutis
+  PR293 #404TV: pranešimų transliacijos ir teletekstas analogine TV ... @kareiva
 
 
 --[ SOUND ]


### PR DESCRIPTION
Transliuosime pranešimus ir camp'o programą (teletekstu) senuoju geruoju analoginiu TV.

9 kanalas 199.250 MHz, garsas +6 MHz