### PR TITLE
Update 404.txt with Osint presentation

### DIFF
--- a/404.txt
+++ b/404.txt
@@ -79,7 +79,7 @@ into some framework" type of topics.
   PR294 Genų inžinerijos pradmenys - kaip gaminamas insulinas ....... @Varlyte90
   PR296 Savanorystė. Kam man to reikia? ................................... Bžik
   PR295 Kosminės tamsoje šviečiančios meno dirbtuvės .......... @justinasjaronis
-
+  PR297 OSINT - atvirų šaltinių žvalgyba @brunislovas
 
 --[ SOUND ]
 


### PR DESCRIPTION
Atvirų šaltinių žvalgyba - nieko naujo, terminas OSINT plačiau pradėtas naudoti po 2014 rusų įvykdyto teroristinio akto prieš MH17 skrydį. Šiuo metu visos pagrindinės pasaulio žvalgybos institucijos tvirtina, kad iš atvirų šaltinių gaunama informacija galimai sudaro didelę dalį ataskaitų turinio. Kas tai yra, kaip tai naudoja Lietuvos institucijos ir kaip jūs galite prisidėti prie šios veiklos. 