### PR TITLE
PX4 Autopilot: add a new ARM chip - RP2350 / Raspberry Pico 2

### DIFF
--- a/404.txt
+++ b/404.txt
@@ -31,6 +31,7 @@ into some framework" type of topics.
   PR301 Collatz Number Cruncher at Tiny Tapeout 05: An Update ............ @rtfb
   PR302 Kodel geriausi investuotojai - mirę investuotojai? ............ Martynas
   PR303 Terminalo kultas ............................................... Brolija
+  PR304 PX4 Autopilot: add a new ARM chip - RP2350 / Raspberry Pico 2 ... @vidma
 
 
 -- [ FOOD & KITCHEN AREA ]


### PR DESCRIPTION
**Why:** RP2350 chip costs ~1$ vs ~10-15+$ for common alternatives from STM32 like F405-H745 which are commonly used in flight controller hardware

**What:** I'll describe my Sisyphus path (as I had no low-level experience with ARM chips) in adding support for a new [RP2350](https://www.raspberrypi.com/products/rp2350/)  microcontroller chip (ARM Cortex M33; the chip used in [Raspberry Pico 2](https://www.raspberrypi.com/products/raspberry-pi-pico-2/) ) to a [PX4 Autopilot software](https://px4.io/).

**How:** At the moment the project is still ongoing, with only a few features working https://github.com/PX4/PX4-Autopilot/pull/24666 however it's much better than the starting point first steps where it was hard to figure out if anything is working. 

I will tell something along these lines:

- how to debug ARM / Raspberry Pico chips (there's no screen/display!)
  - hardware setup: picoprobe for CPU debugging, UART-to-USB converter
  - debugger software: setting up and using `gdb`and  [emdbg](https://pypi.org/project/emdbg/)
- build: compiler flags to specify cpu type, linker LD script (flash and RAM memory layout)
- fixing boot
  * basics, XIP (execute from flash), CPU/clocks init
  * issues: e.g. initial boot was failing apparently because  64bit float divide operation (as simple as `var1 / var2` !!!)  in `cpu clock config code` was getting stuck - executing `00 00` code, as sort of NOP instruction loop, as the required code for 64 bit float operations got linked in RAM, but was not copied from from flash to RAM on boot (thus zeros in RAM as bogus code)
- serial UART (for console/terminal) ✅ 
- something about NuttX OS (basics)
- basic user storage in part of the bootable QSPI flash ✅  (sort of working)
- fixing peripherals support: UART ✅ , I2C ✅ , SPI 🔴 , PWM 🔴 , USB (ttyACM0) 🔴 , maybe mmcsd (sdcard), ...
- maybe multi-core / SMP 🔴 (do not work)
- if time left something about PX4 software

**Context:** 
-  _PX4_ - is a popular Open Source Autopilot software https://px4.io/ . Up to now I'd prefer Ardupilot instead, however, its operating system was much less ready for RP2350 chip than _Nuttx_
- _Nuttx_ is the underlying real-time operating system used by _PX4_. https://github.com/apache/nuttx/pull/14831
- https://www.raspberrypi.com/products/rp2350/
