### PR TITLE
Madflight Autopilot: simple but powerful / Raspberry Pico 2 - RP2350 chip

### DIFF
--- a/404.txt
+++ b/404.txt
@@ -42,6 +42,7 @@ into some framework" type of topics.
   PR312 Nardymas. Ko tikėtis gaunant PADI licenziją ir po to? ........ @adomas-s
   PR313 Litavimo workshopas pradedantiesiems: LED'ai, radijos ir kt ... @kareiva
   PR314 Apie antenas ............................................... @INightmare
+  PR315 Madflight Autopilot: simple but powerful / Raspberry Pico 2 ..... @vidma
 
 -- [ FOOD & KITCHEN AREA ]
 


### PR DESCRIPTION
> https://madflight.com/ is a toolbox to build high performance flight controllers with Aduino IDE or PlatformIO for ESP32-S3 / ESP32 / RP2350 / RP2040 / STM32. A functional DIY flight controller **can be built for under $10 from readily available** [development boards](https://madflight.com/Controller-Boards/) and [sensor breakout boards](https://madflight.com/Sensor-Boards/).


related to other talk #304 , but slightly higher level, as the `madflight` software already works (and is muuuuch simpler!), so I'll show:
- how to set it up - setup is specific to your board, and [done in code, like this](https://github.com/qqqlab/madflight/blob/main/examples/03.Plane/madflight_config.h) and [like this](https://github.com/qqqlab/madflight/blob/main/src/madflight_FC1.h)
- introduce some basic concepts that every flight controller  (FC) uses - sensors (IMU, baro, magnetometer), Receiver, PWM servos
- and if time allows - [a tiny bit on how it works (e.g. PID control loop, AHRS) ...](https://github.com/qqqlab/madflight/blob/8b41cbc48b6a532974b0cadf208bccbabac25b20/examples/03.Plane/03.Plane.ino#L214-L275)

---

DIY build with [Tiny 2350](https://shop.pimoroni.com/products/tiny-2350?variant=42092638699603) and a [6 Eur high end sensors icm-45686 board that someone from Kaunas is selling](https://store.kouno.xyz/products/icm-45686-ist8306-module) :
![madflight_rp2350](https://github.com/user-attachments/assets/a122ab18-791b-49c7-afbc-6298efad851f)


---

will probably also show a proper FC board (to my knowledge first one which uses RP2350 chip) https://madflight.com/Board-FC1/ 

![image](https://github.com/user-attachments/assets/5f733c0f-fecb-4324-b74c-1e716dc57498)
