### PR TITLE
Matuoti visą vandenį

### DIFF
--- a/404.txt
+++ b/404.txt
@@ -56,6 +56,7 @@ into some framework" type of topics.
   PR326 Tatuiruočių stotelė ........................................... Vitalija
   PR328 Pranešimas apie sandėlį, robotus ir konvejerius .............. @liubinas
   PR329 Matuoti visą vandenį ............................................... @rm
+  PR3xx Penktadienį dieną bus WS - laivų dronų vandens mūšis ............... @rm
   PRxxx Sklandymas - geriau 1000km be variklio ar akrobatika su +6, -4G? .. @EVJ
 
 -- [ FOOD & KITCHEN AREA ]

--- a/404.txt
+++ b/404.txt
@@ -56,7 +56,7 @@ into some framework" type of topics.
   PR326 Tatuiruočių stotelė ........................................... Vitalija
   PR328 Pranešimas apie sandėlį, robotus ir konvejerius .............. @liubinas
   PR329 Matuoti visą vandenį ............................................... @rm
-  PR330 Sklandymas - geriau 1000km be variklio ar akrobatika su +6, -4G? .. @EVJ
+  PRxxx Sklandymas - geriau 1000km be variklio ar akrobatika su +6, -4G? .. @EVJ
 
 -- [ FOOD & KITCHEN AREA ]
 

--- a/404.txt
+++ b/404.txt
@@ -55,7 +55,8 @@ into some framework" type of topics.
   PR327 Atvirųjų šaltinių žvalgyba ir tyrimų žurnalistika ...... Mindaugas Aušra
   PR326 Tatuiruočių stotelė ........................................... Vitalija
   PR328 Pranešimas apie sandėlį, robotus ir konvejerius .............. @liubinas
-
+  PR329 Matuoti visą vandenį ............................................... @rm
+  PR330 Sklandymas - geriau 1000km be variklio ar akrobatika su +6, -4G? .. @EVJ
 
 -- [ FOOD & KITCHEN AREA ]
 


### PR DESCRIPTION
Matuoti visą vandenį - laivų dronų platformos projektas su daug sensorikos kuri automatiškai ir labai greitai matuoja vandens sąvybes ir leidžia susidėti greitai į žemėlapius. 
Dabar patestavom kaip tai veikia kaip konkursas mokiniams - puikiai. Norim dar. Matuosim NTA ir darysim laivų betlus.

https://www.facebook.com/hashtag/sailtunities

