### PR TITLE
Antweight robotukų dirbtuvės

### DIFF
--- a/404.txt
+++ b/404.txt
@@ -63,6 +63,7 @@ into some framework" type of topics.
   PR336 Kaip iš veido atpažinti inžinierių? .................... Tomas ir Gabija
   PR337 Šunų dantų priežiūra 101 ................................ Zefyros Draugė
   PR338 Moksliuko nuotykiai su Scientific American ir Google Gemini . @VytautasV
+  PR339 Antweight robotukų dirbtuvės ................................. @juodumas
 
 
 -- [ FOOD & KITCHEN AREA ]


### PR DESCRIPTION
Antweight robotukų dirbtuvės [sugrįžta](https://github.com/ntacamp/404.notrollsallowed.com/pull/188).
Reikės lituoti, susukti korpusą, papuošti savo robotuką ir galiausiai susikauti su kitais dalyviais.
Palyginus su NTA 2023 robotukais, truputį pagerinome dizainą, valdymą ir pridėjome servo varikliuką, prie kurio galima tvirtinti vėliavėlę ar ginklą.

Turėsime 15 rinkinukų, prie pranešimų lentos pakabinsime registracijos lapą.
Dėl nemažos elektronikos komponentų savikainos prašysime įmesti 10-20€ už robotuką.

Valdymas veiks tik su Android telefonu ir Chrome tipo naršyklėmis (tik Chrome leidžia prisijungti prie Bluetooth).
Išeitų paleisti ir alternatyvų būdą per Android/iOS apps'ą, bet tenai valdymas mažiau patogus. Arba atsivežkite savo PS3 gamepad'ą, susiprogramuokite savo valdymą ir būsite nenugalimi!

![x](https://github.com/user-attachments/assets/bc4d0438-ba63-4f45-86c7-f41accd1c5a0)

Rinkinukus sukūrė ir paruošė @TomasSiauliaiNights.