### PR TITLE
Išgyventi Dakarą. Sunkiausias ralis ar geriausios atostogos?

### DIFF
--- a/404.txt
+++ b/404.txt
@@ -73,6 +73,7 @@ into some framework" type of topics.
   PR346 Miesto karščio salos - kas tai ir kaip jas valdyti? ........... MsZefyra
   PR347 Muzikinis protmūšis .............................................. Laima
   PR348 Kaip rašyti be klaidų ...................................... Austėja KMS
+  PR349 Išgyventi Dakarą. Sunkiausias ralis ar geriausios atostogos? ... @darles
 
 
 
@@ -88,8 +89,8 @@ good, follow it.
 --[ DONATIONS ]
 
   * target   : 9000€
-  * donated  : 6946.84€
-  * status   : -2053.16€
+  * donated  : 7202.84€
+  * status   : -1797.16€
 
 The event is free. Free of sponsors too. But we still spend fiat for
 infrastructure and cookies. A rough estimate of event cost is 9000€. If you want
@@ -136,6 +137,7 @@ hall of fame below. For transparency and fame but mostly fame. Thank you!
   Justas Chadasevičius .................................................. 64 EUR
   Julius Stanionis ...................................................... 25 EUR
   Mindina  .............................................................. 84 EUR
+  Darius Leskauskas  ................................................... 256 EUR
 
 
                                     /\_/\


### PR DESCRIPTION
Sudalyvauti sunkiausiomis lenktynėmis tituluojamame Dakaro ralyje buvo mano svajonė nuo vaikystės. Prieš 8 metus pradėjau savo kaip šturmano karjerą ir 2025 sausį kartu su Gintu Petrum pagaliau stovėjau prie šio ralio starto linijos. O po dviejų intensyvių savaičių atsiėmiau ir Dakaro finišo medalį. Papasakosiu kaip viskas atrodė iš vidaus, kodėl žmonės ten braunasi, su kokiais mentaliniais ir fiziniais iššūkiais susidūriau, bei kodėl tai buvo geriausios atostogos.