### PR TITLE
Ardupilot IMU drivers: adding new fancy Murata IMUs

### DIFF
--- a/404.txt
+++ b/404.txt
@@ -26,6 +26,7 @@ into some framework" type of topics.
 
   PR163 Intro: No Trolls Allowed #14 .................................... @pawka
   PR299 Open Kitchen / Bendra Virtuvė ..................................... Visi
+  PR364 Ardupilot IMU drivers: adding new fancy Murata IMUs ............. @vidma
 
 
 -- [ FOOD & KITCHEN AREA ]

--- a/404.txt
+++ b/404.txt
@@ -26,7 +26,7 @@ into some framework" type of topics.
 
   PR163 Intro: No Trolls Allowed #14 .................................... @pawka
   PR299 Open Kitchen / Bendra Virtuvė ..................................... Visi
-  PR364 Ardupilot IMU drivers: adding new fancy Murata IMUs ............. @vidma
+  PR367 Ardupilot IMU drivers: adding new fancy Murata IMUs ............. @vidma
 
 
 -- [ FOOD & KITCHEN AREA ]


### PR DESCRIPTION
my experiences of writing and/or debugging SPI IMU drivers of [Murata SCH16T series IMUs](https://www.murata.com/products/sensor/gyro/overview/lineup/sch16t): K01 (semi-tactical grade, but only 300deg/s gyro range) , SCH16T K10 (more deg/s and higher Gs, but also less accurate), maybe also the latest K20. 

What makes them interesting is relatively low price 50$/chip, and extraordinary performance on paper (but is it true in real life in the air?). 


- how to add a custom/fake external SPI breakout on a cheap 45$ [MicoAir743-Lite](https://store.micoair.com/product/micoair743-lite/) flight controller using existing pins (just one pin need to be soldered to directly to chip, others using existing connectors - getting stable ~8 MHz SPI)
- Murata IMUs have no FIFO, so reads can not lag (use DRDY pin, run in separate high-priority thread)
- debugging reading (e.g. skipped or inconsistent reads) and other errors 
- in flight debugging on Airplane UAV (as of 5 May - it flies, but something is still a bit buggy)
- ...