### PR TITLE
Kaip tirti Lietuvos interneto raidą?

### DIFF
--- a/404.txt
+++ b/404.txt
@@ -45,6 +45,7 @@ commercial sh*t, "intro to some framework" type of topics.
   PR384 Peilių galandinimo dirbtuvės/mokymai ........................ @Richardas
   PR385 Perpetual Stew/Amžinas troškinys ............................ @Richardas
   PR386 Teaching a local machine to read manga ................ @tankiaitaskuota
+  PR042 Kaip tirti Lietuvos interneto raidą? ..........@mrmktb @postscriptum1984
 
 -- [ FOOD & KITCHEN AREA ]
 

--- a/404.txt
+++ b/404.txt
@@ -45,7 +45,7 @@ commercial sh*t, "intro to some framework" type of topics.
   PR384 Peilių galandinimo dirbtuvės/mokymai ........................ @Richardas
   PR385 Perpetual Stew/Amžinas troškinys ............................ @Richardas
   PR386 Teaching a local machine to read manga ................ @tankiaitaskuota
-  PR042 Kaip tirti Lietuvos interneto raidą? ..........@mrmktb @postscriptum1984
+  PR387 Kaip tirti Lietuvos interneto raidą? ......... @mrmktb @postscriptum1984
 
 -- [ FOOD & KITCHEN AREA ]
 


### PR DESCRIPTION
interneto istorija LT istorikams per nauja, o sociologams – per sena. imam reikalą į savo rankas. 

papasakosime apie slow science projektą, kurio tikslas – sudėlioti LT interneto chronologiją (kas buvo prieš IRC? o prieš BBS? o prieš Fido?), svarbius personažus ir personažes, folklorą, lūžio ir pokyčio taškus. modemų kleketavimai, telekomo privatizacija, linkomanija, naktys prie terminalo langelių, blogofermos ir startupai, valstybinio IT peripetijos, pletkai, brainrotai – viskas susiję. 

dalinsimės, kas ryškėja šitame 30+ metų inovacijų ir deviacijų detektyve. guosimės medijų archeologijos sunkumais. kviesime prisidėti prie užuominų rinkimo.